### PR TITLE
feat: Añadir opciones para guardar, listar y resumir conexiones

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Crédito: 1.12 CUC
 
 #### Determinar si hay conexión a internet
 
-```text
+```bash
 nauta is-online
 ```
 
@@ -101,7 +101,7 @@ Online: No
 
 #### Determinar si hay una sesión abierta
 
-```text
+```bash
 nauta is-logged-in
 ```
 
@@ -110,6 +110,38 @@ __Salida__:
 Sesión activa: No
 ```
     
+## Opciones adicionales
+
+### `--list-connections`
+
+Muestra una lista de todas las conexiones de todos los usuarios almacenadas en la base de datos.
+
+```bash
+nauta --list-connections
+```
+
+### `--resume-connections`
+
+Genera un resumen mensual de todas las conexiones, agrupadas por usuario, mostrando la cantidad total de horas conectadas en cada mes.
+
+```bash
+nauta --resume-connections
+```
+
+### Estas dos opciones anteriores se pueden combinar:
+
+```bash
+nauta --list-connections --resume-connections
+```
+
+### `--no-log`
+
+Evita que se registre la conexión actual en la base de datos.
+
+```bash
+nauta up -t 2h --no-log
+```
+
 # Más Información
 
 Lee la ayuda del módulo una vez instalado:

--- a/nautapy/sqlite_utils.py
+++ b/nautapy/sqlite_utils.py
@@ -1,0 +1,186 @@
+import os
+import sqlite3
+from base64 import b85encode, b85decode
+from datetime import datetime
+from getpass import getpass
+
+from nautapy import appdata_path
+
+# Base de datos de los usuarios
+USERS_DB = os.path.join(appdata_path, "users.db")
+# Base de datos de las conexiones hechas por los usuarios
+CONNECTIONS_DB = os.path.join(appdata_path, "connections.db")
+
+
+def users_db_connect():
+    conn = sqlite3.connect(USERS_DB)
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE IF NOT EXISTS users (user TEXT, password TEXT)")
+    cursor.execute("CREATE TABLE IF NOT EXISTS default_user (user TEXT)")
+
+    conn.commit()
+    return cursor, conn
+
+
+def _get_default_user():
+    cursor, _ = users_db_connect()
+
+    # Search for explicit default value
+    cursor.execute("SELECT user FROM default_user LIMIT 1")
+    rec = cursor.fetchone()
+    if rec:
+        return rec[0]
+
+    # If no explicit value exists, find the first user
+    cursor.execute("SELECT * FROM users LIMIT 1")
+
+    rec = cursor.fetchone()
+    if rec:
+        return rec[0]
+
+
+def _find_credentials(user, default_password=None):
+    cursor, _ = users_db_connect()
+    cursor.execute("SELECT * FROM users WHERE user LIKE ?", (user + "%",))
+
+    rec = cursor.fetchone()
+    if rec:
+        return rec[0], b85decode(rec[1]).decode("utf-8")
+    else:
+        return user, default_password
+
+
+def add_user(args):
+    password = args.password or getpass("Contraseña para {}: ".format(args.user))
+
+    cursor, connection = users_db_connect()
+    cursor.execute(
+        "INSERT INTO users VALUES (?, ?)",
+        (args.user, b85encode(password.encode("utf-8"))),
+    )
+    connection.commit()
+
+    print("Usuario guardado: {}".format(args.user))
+
+
+def set_default_user(args):
+    cursor, connection = users_db_connect()
+    cursor.execute("SELECT count(user) FROM default_user")
+    res = cursor.fetchone()
+
+    if res[0]:
+        cursor.execute("UPDATE default_user SET user=?", (args.user,))
+    else:
+        cursor.execute("INSERT INTO default_user VALUES (?)", (args.user,))
+
+    connection.commit()
+
+    print("Usuario predeterminado: {}".format(args.user))
+
+
+def remove_user(args):
+    cursor, connection = users_db_connect()
+    cursor.execute("DELETE FROM users WHERE user=?", (args.user,))
+    connection.commit()
+
+    print("Usuario eliminado: {}".format(args.user))
+
+
+def set_password(args):
+    password = args.password or getpass("Contraseña para {}: ".format(args.user))
+
+    cursor, connection = users_db_connect()
+    cursor.execute(
+        "UPDATE users SET password=? WHERE user=?",
+        (b85encode(password.encode("utf-8")), args.user),
+    )
+
+    connection.commit()
+
+    print("Contraseña actualizada: {}".format(args.user))
+
+
+def list_users(args):
+    cursor, _ = users_db_connect()
+
+    for rec in cursor.execute("SELECT user FROM users"):
+        print(rec[0])
+
+
+def create_connections_db():
+    conn = sqlite3.connect(CONNECTIONS_DB)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS connections (
+            user TEXT,
+            fecha_inicio_sesion DATETIME,
+            fecha_cierre_sesion DATETIME
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_login(user):
+    create_connections_db()
+    conn = sqlite3.connect(CONNECTIONS_DB)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO connections (user, fecha_inicio_sesion)
+        VALUES (?, ?)
+        """,
+        (user, datetime.now()),
+    )
+    conn.commit()
+    conn.close()
+
+
+def save_logout(user):
+    # create_connections_db()
+    conn = sqlite3.connect(CONNECTIONS_DB)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        UPDATE connections
+        SET fecha_cierre_sesion = ?
+        WHERE user = ? AND fecha_cierre_sesion IS NULL
+        AND fecha_inicio_sesion = (
+            SELECT MAX(fecha_inicio_sesion)
+            FROM connections
+            WHERE user = ?
+        )
+        """,
+        (datetime.now(), user, user)
+    )
+    conn.commit()
+    conn.close()
+
+
+def list_connections(args):
+    # Asegurarse de que la base de datos de conexiones esté creada
+    create_connections_db()
+
+    # Conectarse a la base de datos
+    conn = sqlite3.connect(CONNECTIONS_DB)
+    cursor = conn.cursor()
+
+    # Ejecutar la consulta para obtener los datos de las conexiones
+    cursor.execute(
+        """
+        SELECT user, fecha_inicio_sesion, fecha_cierre_sesion
+        FROM connections
+        ORDER BY fecha_inicio_sesion
+        """
+    )
+
+    # Obtener todos los registros y almacenarlos en una lista
+    connections = cursor.fetchall()
+
+    # Cerrar la conexión a la base de datos
+    conn.close()
+
+    # Devolver los registros obtenidos
+    return connections

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,9 +1,8 @@
-beautifulsoup4==4.8.1
-bs4==0.0.1
-certifi==2022.12.7
-chardet==3.0.4
-idna==2.8
-requests==2.27.1
-soupsieve==1.9.5
-urllib3==1.26.8
-psutil==5.9.8
+beautifulsoup4~=4.12.3
+certifi~=2024.8.30
+chardet~=5.2.0
+idna~=3.10
+requests~=2.32.3
+soupsieve~=2.6
+urllib3==1.26.8 # no se puede actualizar: https://github.com/urllib3/urllib3/issues/3100
+psutil~=6.0.0


### PR DESCRIPTION
Se añade las siguientes opciones a la CLI de Nauta:

- **`--list-connections`**: Muestra una lista de todas las conexiones de los usuarios almacenadas en la base de datos, con detalles como el usuario, fecha de inicio y fecha de cierre de sesión.
- **`--resume-connections`**: Genera un resumen mensual de las horas conectadas por usuario, mostrando la cantidad total de horas conectadas en cada mes, agrupado por usuario. Los meses se muestran en español y solo aparecen aquellos que tienen datos.
- **Combinación de opciones**: Estas dos opciones pueden utilizarse conjuntamente para listar y resumir las conexiones.
- **`--no-log`**: Evita que se registre la conexión actual en la base de datos, útil para sesiones que no deben ser guardadas.

---

### Descripción del funcionamiento:

- **Registro de conexiones en la base de datos**:
  - Se implementa el guardado de las conexiones de los usuarios, con la información de inicio y cierre de sesión en la base de datos SQLite.

- **Nueva funcionalidad `resume_connections`**:
  - Calcula y muestra un resumen de las horas de conexión por usuario, agrupado por mes. Se excluyen conexiones que no tienen fecha de cierre de sesión.
  - El resultado se presenta en una tabla con las siguientes columnas:
    - Usuario.
    - Mes (en español).
    - Cantidad total de horas conectadas, formateadas con dos decimales.

- **Base de datos de usuarios y conexiones**:
  - El archivo `sqlite_utils.py` maneja la creación, actualización y consulta de dos bases de datos:
    - **`users.db`**: Almacena la información de los usuarios y sus credenciales.
    - **`connections.db`**: Almacena los registros de conexiones de los usuarios con detalles de fecha y hora de inicio y cierre de sesión.
