### PR TITLE
Mejoras en el sistema de conexiones: formato de tiempo, cierre de sesiones y filtros CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,34 +112,82 @@ Sesión activa: No
     
 ## Opciones adicionales
 
-### `--list-connections`
+### `--list-conn`, `-lc` 
 
-Muestra una lista de todas las conexiones de todos los usuarios almacenadas en la base de datos.
+Muestra una lista de las conexiones del mes actual de todos los usuarios almacenadas en la base de datos.
 
 ```bash
-nauta --list-connections
+nauta --list-conn
 ```
 
-### `--resume-connections`
+**Opciones de filtrado:**
+
+* **`--last-month`, `-lm`, :** Muestra solo las conexiones del mes anterior.
+* **`--all-conn`, `-ac`:** Muestra todas las conexiones, sin importar el mes.
+
+```bash
+# Mostrar conexiones del mes anterior:
+nauta --list-conn --last-month
+
+# Mostrar todas las conexiones:
+nauta --list-conn --all-conn
+```
+
+### `--resume-conn`, `-rc`
 
 Genera un resumen mensual de todas las conexiones, agrupadas por usuario, mostrando la cantidad total de horas conectadas en cada mes.
 
 ```bash
-nauta --resume-connections
+nauta --resume-conn
 ```
 
-### Estas dos opciones anteriores se pueden combinar:
+### Combinando opciones
+
+Puedes combinar las opciones para obtener resultados más específicos. Por ejemplo:
 
 ```bash
-nauta --list-connections --resume-connections
+# Mostrar un resumen mensual y todas las conexiones
+nauta -rc -lc -ac
 ```
 
-### `--no-log`
+```bash
+# Mostrar las conexiones del mes pasado
+nauta -lc -lm
+```
 
-Evita que se registre la conexión actual en la base de datos.
+**Nota:** Las opciones `--last-month` y `--all-conn` solo afectan al comando `--list-conn`.
+
+**Explicación detallada:**
+
+* **`--last-month`:** Esta opción permite filtrar las conexiones y mostrar solo aquellas que ocurrieron en el mes anterior.
+* **`--all-conn`:** Con esta opción, se mostrarán todas las conexiones almacenadas en la base de datos, sin aplicar ningún filtro por fecha.
+
+**Ejemplo de uso completo:**
+
+```bash
+nauta --list-conn --last-month --resume-conn
+```
+
+Este comando mostrará:
+
+1. Una lista de todas las conexiones del mes anterior.
+2. Un resumen mensual de todas las conexiones.
+
+**Consideraciones adicionales:**
+
+* **Orden de las opciones:** El orden de las opciones no suele importar.
+* **Opciones mutuamente excluyentes:** En este caso, no hay opciones mutuamente excluyentes. Puedes combinarlas como quieras.
+
+### `--no-log`, `-nl`
+
+Evita que se registre la conexión actual en la base de datos:
 
 ```bash
 nauta up -t 2h --no-log
+```
+de la misma manera usando opciones cortas:
+```bash
+nauta up -t 2h -nl
 ```
 
 # Más Información

--- a/nautapy/cli.py
+++ b/nautapy/cli.py
@@ -302,11 +302,18 @@ def resume_connections(args):
         # Cabecera de la tabla
         headers = ["Usuario", "Mes", "Cantidad de horas"]
 
-        rows = [
-            [user, mes_anio.capitalize(), f"{horas:.2f} horas"]
-            for user, hours_per_month in user_hours_per_month.items()
-            for mes_anio, horas in sorted(hours_per_month.items())
-        ]
+        rows = []
+        for user, hours_per_month in user_hours_per_month.items():
+            for mes_anio, horas in sorted(hours_per_month.items()):
+                horas_int = int(horas)
+                minutos = int((horas - horas_int) * 60)
+                if horas_int == 0:
+                    horas_str = f"{minutos} minutos"
+                elif minutos == 0:
+                    horas_str = f"{horas_int} horas"
+                else:
+                    horas_str = f"{horas_int} hora{'s' if horas_int > 1 else ''} {minutos} minuto{'s' if minutos > 1 else ''}"
+                rows.append([user, mes_anio.capitalize(), horas_str])
 
         col_widths = [
             max(len(str(row[i])) for row in rows + [headers])

--- a/nautapy/cli.py
+++ b/nautapy/cli.py
@@ -13,7 +13,8 @@ from nautapy.__about__ import __cli__ as prog_name, __version__ as version
 from nautapy.exceptions import NautaException
 from nautapy.nauta_api import NautaClient, NautaProtocol
 from nautapy.sqlite_utils import _get_default_user, save_login, save_logout, add_user, set_default_user, set_password, \
-    remove_user, list_users, _find_credentials, list_connections
+    remove_user, list_users, _find_credentials, list_connections, list_connections_current_month, \
+    list_connections_last_month
 
 
 def _get_credentials(args):
@@ -206,8 +207,15 @@ def create_user_subparsers(subparsers):
 
 
 def list_connections_cli(args):
-    # Obtener las conexiones desde sqlite_utils
-    connections = list_connections(args)
+    if args.last_month:
+        # Obtener las conexiones desde sqlite_utils, las del mes pasado
+        connections = list_connections_last_month(args)
+    elif args.all_conn:
+        # Obtener las conexiones desde sqlite_utils, todas las conexiones
+        connections = list_connections(args)
+    else:
+        # Obtener las conexiones desde sqlite_utils, por defecto las del mes actual
+        connections = list_connections_current_month(args)
 
     # Asegurarse de que connections no sea None
     if connections is None or len(connections) == 0:
@@ -251,7 +259,7 @@ def list_connections_cli(args):
     # Mostrar la tabla
     print("\n".join(table))
     # Si se pide el resumen, se muestra al final de la tabla
-    if args.resume_connections:
+    if args.resume_conn:
         resume_connections(args)
 
 
@@ -340,17 +348,33 @@ def main():
         "--version", action="version", version="{} v{}".format(prog_name, version)
     )
     parser.add_argument("-d", "--debug", action="store_true", help="show debug info")
-    # listar las conexiones de todos los usuarios
+    # listar las conexiones de todos los usuarios, solo las del mes actual
     parser.add_argument(
         "-lc",
-        "--list-connections",
+        "--list-conn",
         action="store_true",
         default=False,
-        help="Lista todas las conexiones de los usuarios")
+        help="Lista las conexiones del mes actual de los usuarios")
+    # Solo muestra las conexiones del mes pasado
+    parser.add_argument(
+        "-lm",
+        "--last-month",
+        action="store_true",
+        default=False,
+        help="Lista las conexiones del mes anterior"
+    )
+    # Muestra todas las conexiones
+    parser.add_argument(
+        "-ac",
+        "--all-conn",
+        action="store_true",
+        default=False,
+        help="Lista todas las conexiones de los usuarios"
+    )
     # Resumen mensual de las conexiones por usuario
     parser.add_argument(
         "-rc",
-        "--resume-connections",
+        "--resume-conn",
         action="store_true",
         default=False,
         help="Hace un resumen mensual de todas las conexiones, por usuario",
@@ -422,13 +446,21 @@ def main():
 
     args = parser.parse_args()
 
+    # Chequeo que usen --last-month con --list-connections
+    if args.last_month and not args.list_conn:
+        parser.error("--last-month requiere --list-conn")
+
+    # Chequeo que usen --all-conn con --list-conn
+    if args.all_conn and not args.list_conn:
+        parser.error("--all-conn requiere --list-conn")
+
     # Muestra las conexiones de los usuarios en la BD
-    if args.list_connections:
+    if args.list_conn:
         list_connections_cli(args)
         sys.exit(0)
 
     # Muestra un resumen mensual de las conexiones
-    if args.resume_connections:
+    if args.resume_conn:
         resume_connections(args)
         sys.exit(0)
 

--- a/nautapy/sqlite_utils.py
+++ b/nautapy/sqlite_utils.py
@@ -151,6 +151,7 @@ def save_logout(user):
             SELECT MAX(fecha_inicio_sesion)
             FROM connections
             WHERE user = ?
+            AND fecha_cierre_sesion IS NULL
         )
         """,
         (datetime.now(), user, user)

--- a/nautapy/sqlite_utils.py
+++ b/nautapy/sqlite_utils.py
@@ -185,3 +185,79 @@ def list_connections(args):
 
     # Devolver los registros obtenidos
     return connections
+
+
+def list_connections_current_month(args):
+    # Asegurarse de que la base de datos de conexiones esté creada
+    create_connections_db()
+
+    # Conectarse a la base de datos
+    conn = sqlite3.connect(CONNECTIONS_DB)
+    cursor = conn.cursor()
+
+    # Obtener el mes y año actual
+    current_date = datetime.now()
+    current_month = current_date.month
+    current_year = current_date.year
+
+    # Ejecutar la consulta para obtener los datos de las conexiones del mes actual
+    cursor.execute(
+        """
+        SELECT user, fecha_inicio_sesion, fecha_cierre_sesion
+        FROM connections
+        WHERE strftime('%m', fecha_inicio_sesion) = ? AND strftime('%Y', fecha_inicio_sesion) = ?
+        ORDER BY fecha_inicio_sesion
+        """,
+        (f'{current_month:02}', str(current_year))
+    )
+
+    # Obtener todos los registros y almacenarlos en una lista
+    connections = cursor.fetchall()
+
+    # Cerrar la conexión a la base de datos
+    conn.close()
+
+    # Devolver los registros obtenidos
+    return connections
+
+
+def list_connections_last_month(args):
+    # Asegurarse de que la base de datos de conexiones esté creada
+    create_connections_db()
+
+    # Conectarse a la base de datos
+    conn = sqlite3.connect(CONNECTIONS_DB)
+    cursor = conn.cursor()
+
+    # Obtener el mes y año actual
+    current_date = datetime.now()
+    current_month = current_date.month
+    current_year = current_date.year
+
+    # Calcular el mes y año anterior
+    if current_month == 1:
+        past_month = 12
+        past_year = current_year - 1
+    else:
+        past_month = current_month - 1
+        past_year = current_year
+
+    # Ejecutar la consulta para obtener los datos de las conexiones del mes anterior
+    cursor.execute(
+        """
+        SELECT user, fecha_inicio_sesion, fecha_cierre_sesion
+        FROM connections
+        WHERE strftime('%m', fecha_inicio_sesion) = ? AND strftime('%Y', fecha_inicio_sesion) = ?
+        ORDER BY fecha_inicio_sesion
+        """,
+        (f'{past_month:02}', str(past_year))
+    )
+
+    # Obtener todos los registros y almacenarlos en una lista
+    connections = cursor.fetchall()
+
+    # Cerrar la conexión a la base de datos
+    conn.close()
+
+    # Devolver los registros obtenidos
+    return connections


### PR DESCRIPTION
- feat: formatear tiempo restante en el resumen mensual de conexiones
  - Se implementa el formato mejorado para mostrar las horas y minutos en la función `resume_connections`
  - Por ej: 12 horas 23 minutos

- fix: Cierra la sesión mas reciente en caso que hayan varias antiguas abiertas
  - En caso que se hayan quedado algunas sesiones antiguas abiertas, solo se cierra la mas reciente que no se haya cerrado aún
  
- feat(cli): Añade filtros para listar conexiones por mes
  - Se cambia el flag `--list-connections` a `--list-conn`
  - Se cambia el flag `--resume-connections` a `--resume-conn`
  - Se añaden los argumentos `--last-month`, `-lm` y `--all-conn`, `-ac` al comando `--list-conn`, `-lc` para permitir filtrar las conexiones por mes, o mostrar todas las conexiones
  - Se incluyen validaciones para asegurar un uso correcto de estos argumentos. Se amplía la funcionalidad de la base de datos para soportar estas nuevas consultas